### PR TITLE
Add toeplitz.svd method

### DIFF
--- a/inst/extdata/common.test.methods.R
+++ b/inst/extdata/common.test.methods.R
@@ -76,8 +76,6 @@ make.test.data <- function(what = c("reconstruct", "rforecast", "vforecast"),
   kind <- match.arg(kind);
   svd.method <- match.arg(svd.method);
   svd.methods <- sapply(svd.methods, match.arg, choices = eval(formals()$svd.methods));
-  if (identical(kind, "toeplitz-ssa"))
-    svd.methods <- svd.methods[svd.methods != "svd"];
 
   out <- list(series = series);
 
@@ -146,8 +144,6 @@ test.test.data <- function(what,
   } else {
     svd.methods <- sapply(svd.methods, match.arg, choices = c("eigen", "propack", "svd", "nutrlan"));
   }
-  if (identical(kind, "toeplitz-ssa"))
-    svd.methods <- svd.methods[svd.methods != "svd"];
 
   series <- test.data$series;
   Ls <- pars$Ls;


### PR DESCRIPTION
Anton!

This is dull classic-svd application for toeplitz case.
I think, it's may be useful for
1) Fun and fullness
2) Checking and testing propack.svd (do you remember case with negative eigenvalues?)
3) Uniforming autotesting (and other batch procedures). We will can test toeplitz.ssa the same way as classic 1d.ssa

Alex
